### PR TITLE
- FIX: In case the DataTransferOrign was MICS, the generated IDs were…

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML.Test/UnitTest1.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML.Test/UnitTest1.cs
@@ -56,5 +56,66 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Test
 
         }
 
+        [TestMethod]
+        public void DoesRecognizeDataOrignFMIS()
+        {
+            var isoxml = ISOXML.Create("test");
+            isoxml.DataTransferOrigin = ISO11783TaskDataFileDataTransferOrigin.FMIS;
+            var device = new ISODevice()
+            {
+                DeviceDesignator = "Machine"
+            };
+
+            var partfield = new ISOPartfield()
+            {
+                PartfieldDesignator = "Field"
+            };
+
+            var partfield2 = new ISOPartfield()
+            {
+                PartfieldDesignator = "Field2"
+            };
+
+            var deviceResult = isoxml.IdTable.AddObjectAndAssignIdIfNone(device);
+            Assert.AreEqual("DVC1", device.DeviceId);
+            var partFieldResult = isoxml.IdTable.AddObjectAndAssignIdIfNone(partfield);
+            Assert.AreEqual("PFD1", partfield.PartfieldId);
+            var partFieldResult2 = isoxml.IdTable.AddObjectAndAssignIdIfNone(partfield2);
+            Assert.AreEqual("PFD2", partfield2.PartfieldId);
+
+
+
+        }
+
+        [TestMethod]
+        public void DoesRecognizeDataOrignMICS()
+        {
+            var isoxml = ISOXML.Create("test");
+            isoxml.DataTransferOrigin = ISO11783TaskDataFileDataTransferOrigin.MICS;
+            var device = new ISODevice()
+            {
+                DeviceDesignator = "Machine"
+            };
+
+            var partfield = new ISOPartfield()
+            {
+                PartfieldDesignator = "Field"
+            };
+
+            var partfield2 = new ISOPartfield()
+            {
+                PartfieldDesignator = "Field2"
+            };
+
+            var deviceResult = isoxml.IdTable.AddObjectAndAssignIdIfNone(device);
+            Assert.AreEqual("DVC-1", device.DeviceId);
+            var partFieldResult = isoxml.IdTable.AddObjectAndAssignIdIfNone(partfield);
+            Assert.AreEqual("PFD-1", partfield.PartfieldId);
+            var partFieldResult2 = isoxml.IdTable.AddObjectAndAssignIdIfNone(partfield2);
+            Assert.AreEqual("PFD-2", partfield2.PartfieldId);
+
+
+
+        }
     }
 }

--- a/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
@@ -4,7 +4,7 @@
     {
         //TODO It's more save to move this Element to a common class. It's found in Generator and DotnetCore Library
         public static string ISOXMLClassName = "Dev4Agriculture.ISO11783.ISOXML";
-        public static string Version = "V0.19.5.1";//Currently unused; Just for the commit
+        public static string Version = "V0.19.5.2";//Currently unused; Just for the commit
         public static string Author = "Frank Wiebeler, dev4Agriculture";
         public const int TLG_VALUE_FOR_NO_VALUE = int.MinValue;
         public const double EarthRadiusInMeters = 6378137;

--- a/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
+++ b/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Dev4Agriculture.ISO11783.ISOXML</RootNamespace>
-    <Version>0.19.5.1</Version>
+    <Version>0.19.5.2</Version>
     <Company>dev4Agriculture</Company>
     <Title>ISOXML DotNet Library</Title>
     <Authors>Frank Wiebeler, Alexander Parshin, Dima Robuliak</Authors>
@@ -16,9 +16,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>isoxml;agriculture;iso11783;taskcontroller;taskdata.xml;taskdata;smart-farming;farming</PackageTags>
-    <Version>0.19.5.1</Version>
-    <AssemblyVersion>0.19.5.1</AssemblyVersion>
-    <FileVersion>0.19.5.1</FileVersion>
+    <Version>0.19.5.2</Version>
+    <AssemblyVersion>0.19.5.2</AssemblyVersion>
+    <FileVersion>0.19.5.2</FileVersion>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/RELEASE-Notes.txt"))</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
@@ -171,6 +171,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML
                 {
                     LinkList.DataTransferOrigin = (ISO11783LinkListFileDataTransferOrigin)value;
                 }
+                IdList.DataOrign = value;
             }
         }
 

--- a/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
+++ b/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
@@ -1,3 +1,6 @@
+v0.19.5.2
+- FIX: In case the DataTransferOrign was MICS, the generated IDs were still positive as the TransferOrign was not handed on to the IDList
+
 v0.19.5.1
 - FIX: In case 2 polygons were compared of which one was closed and one was not, the overlap algorithm might in some cases not recognize the equality of both polygons
 v0.19.5


### PR DESCRIPTION
… still positive as the TransferOrign was not handed on to the IDList