### PR TITLE
Avoid crashes on reading empty lists

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML.Test/ResultMessagesTest.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML.Test/ResultMessagesTest.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 
 namespace Dev4Agriculture.ISO11783.ISOXML.Test;
 [TestClass]
@@ -22,6 +25,13 @@ public class ResultMessagesTest
         Assert.AreEqual(isoxml.Messages.Count, 13);
         Assert.AreEqual(isoxml.Messages[1].Title, "FileNotFound");
 
+    }
+
+    [TestMethod]
+    public void TestMessageSerializationWorks() {
+        var isoxml = ISOXML.Load("./testdata/ResultMessages/BrokenBinFile");
+        string result = JsonConvert.SerializeObject(isoxml.Messages);
+        Assert.IsTrue(Regex.Matches(result,"Code").Count == 13);
     }
 
 }

--- a/Dev4Agriculture.ISO11783.ISOXML.Test/TaskDataAnalysisTests.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML.Test/TaskDataAnalysisTests.cs
@@ -52,5 +52,16 @@ public class TaskDataAnalysisTests
         Assert.AreEqual(entries.Data.Count, 2);
         Assert.AreEqual(filledEntries.Data.Count, 4677);
     }
+
+    [TestMethod]
+    public void CanReadDataLogValues()
+    {
+        var isoxml = ISOXML.Load("./testdata/TimeLogs/TotalsTests");
+        //Testing TIM-wise ValueReading.
+        //This is found <DLV A="0094" B="1000" C="DET-1"/>
+        Assert.IsTrue(isoxml.Data.Task[0].Time[0].TryGetDDIValue(148, -1, out int result));
+        Assert.AreEqual(result, (int)1000);
+        Assert.IsFalse(isoxml.Data.Task[0].Time[0].TryGetDDIValue(148, 1, out int result2));
+    }
 }
 

--- a/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
@@ -4,7 +4,7 @@
     {
         //TODO It's more save to move this Element to a common class. It's found in Generator and DotnetCore Library
         public static string ISOXMLClassName = "Dev4Agriculture.ISO11783.ISOXML";
-        public static string Version = "V0.19.5.2";//Currently unused; Just for the commit
+        public static string Version = "V0.19.5.4";//Currently unused; Just for the commit
         public static string Author = "Frank Wiebeler, dev4Agriculture";
         public const int TLG_VALUE_FOR_NO_VALUE = int.MinValue;
         public const double EarthRadiusInMeters = 6378137;

--- a/Dev4Agriculture.ISO11783.ISOXML/Converters/V3Converter.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Converters/V3Converter.cs
@@ -57,8 +57,15 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Converters
                     }
 
                     //p.129
-                    trZone.ProcessDataVariable.First().ActualCulturalPracticeValue = null;
-                    trZone.ProcessDataVariable.First().ElementTypeInstanceValue = null;
+                    if( trZone.ProcessDataVariable.Count > 0)
+                    {
+                        trZone.ProcessDataVariable.First().ActualCulturalPracticeValue = null;
+                    }
+
+                    if(trZone.ProcessDataVariable.Count > 0)
+                    {
+                        trZone.ProcessDataVariable.First().ElementTypeInstanceValue = null;
+                    }
 
                     if (trZone.PolygonTreatmentZoneonly.Count > 1)
                     {

--- a/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
+++ b/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Dev4Agriculture.ISO11783.ISOXML</RootNamespace>
-    <Version>0.19.5.2</Version>
+    <Version>0.19.5.4</Version>
     <Company>dev4Agriculture</Company>
     <Title>ISOXML DotNet Library</Title>
     <Authors>Frank Wiebeler, Alexander Parshin, Dima Robuliak</Authors>
@@ -16,9 +16,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>isoxml;agriculture;iso11783;taskcontroller;taskdata.xml;taskdata;smart-farming;farming</PackageTags>
-    <Version>0.19.5.2</Version>
-    <AssemblyVersion>0.19.5.2</AssemblyVersion>
-    <FileVersion>0.19.5.2</FileVersion>
+    <Version>0.19.5.4</Version>
+    <AssemblyVersion>0.19.5.4</AssemblyVersion>
+    <FileVersion>0.19.5.4</FileVersion>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/RELEASE-Notes.txt"))</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISODeviceExtension.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISODeviceExtension.cs
@@ -103,12 +103,12 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
 
         public bool IsTotal(ushort DDI)
         {
-            return DeviceProcessData.First(entry => DDIUtils.ConvertDDI(entry.DeviceProcessDataDDI) == DDI)?.IsTotal() ?? false;
+            return DeviceProcessData.FirstOrDefault(entry => DDIUtils.ConvertDDI(entry.DeviceProcessDataDDI) == DDI)?.IsTotal() ?? false;
         }
 
         public bool IsLifetimeTotal(ushort DDI)
         {
-            return DeviceProcessData.First(entry => DDIUtils.ConvertDDI(entry.DeviceProcessDataDDI) == DDI)?.IsLifeTimeTotal() ?? false;
+            return DeviceProcessData.FirstOrDefault(entry => DDIUtils.ConvertDDI(entry.DeviceProcessDataDDI) == DDI)?.IsLifeTimeTotal() ?? false;
         }
 
     }

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOTaskExtension.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOTaskExtension.cs
@@ -200,7 +200,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
             if (shallCheckTimeElements)
             {
                 var endTime = Time.Max(entry => entry.Start);
-                if (Time.First(entry => entry.Start == endTime).TryGetDDIValue(ddi, deviceElement, out lastValue))
+                if (Time.FirstOrDefault(entry => entry.Start == endTime)?.TryGetDDIValue(ddi, deviceElement, out lastValue) ?? false)
                 {
                     return true;
                 }
@@ -238,7 +238,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
                 if (shallCheckTimeElements)
                 {
                     var endTime = Time.Max(entry => entry.Start);
-                    if (Time.First(entry => entry.Start == endTime).TryGetDDIValue(ddi, deviceElement, out totalValue))
+                    if (Time.FirstOrDefault(entry => entry.Start == endTime)?.TryGetDDIValue(ddi, deviceElement, out totalValue) ?? false)
                     {
                         return true;
                     }
@@ -260,7 +260,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
                 if (shallCheckTimeElements)
                 {
                     var endTime = Time.Max(entry => entry.Start);
-                    if (Time.First(entry => entry.Start == endTime).TryGetDDIValue(ddi, deviceElement, out totalValue))
+                    if (Time.FirstOrDefault(entry => entry.Start == endTime)?.TryGetDDIValue(ddi, deviceElement, out totalValue) ?? false)
                     {
                         return true;
                     }

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOTimeExtension.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOTimeExtension.cs
@@ -71,20 +71,23 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
         {
             foreach (var dlv in tim.DataLogValue)
             {
-                var compare = lastTim.DataLogValue.First(entry =>
+                var compare = lastTim.DataLogValue.FirstOrDefault(entry =>
                                                             DDIUtils.ConvertDDI(entry.ProcessDataDDI) == DDIUtils.ConvertDDI(dlv.ProcessDataDDI) &&
                                                             entry.DeviceElementIdRef == dlv.DeviceElementIdRef
                                                         );
                 if (compare != null)
                 {
-                    var device = devices.First(dvc => dvc.DeviceElement.Any(det => det.DeviceElementId == dlv.DeviceElementIdRef));
-                    if (device.IsLifetimeTotal(DDIUtils.ConvertDDI(dlv.ProcessDataDDI)))
+                    var device = devices.FirstOrDefault(dvc => dvc.DeviceElement.Any(det => det.DeviceElementId == dlv.DeviceElementIdRef));
+                    if (device != null)
                     {
-                        dlv.ProcessDataValue = compare.ProcessDataValue;
-                    }
-                    else
-                    {
-                        dlv.ProcessDataValue += compare.ProcessDataValue;
+                        if (device.IsLifetimeTotal(DDIUtils.ConvertDDI(dlv.ProcessDataDDI)))
+                        {
+                            dlv.ProcessDataValue = compare.ProcessDataValue;
+                        }
+                        else
+                        {
+                            dlv.ProcessDataValue += compare.ProcessDataValue;
+                        }
                     }
                 }
             }
@@ -101,7 +104,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
         /// <returns>True if a value was found</returns>
         public bool TryGetDDIValue(ushort ddi, int deviceElement, out int lastValue)
         {
-            var dlv = DataLogValue.ToList().First(entry => DDIUtils.ConvertDDI(entry.ProcessDataDDI) == ddi && IdList.ToIntId(entry.DeviceElementIdRef) == deviceElement)?.ProcessDataValue;
+            var dlv = DataLogValue.ToList().FirstOrDefault(entry => DDIUtils.ConvertDDI(entry.ProcessDataDDI) == ddi && IdList.ToIntId(entry.DeviceElementIdRef) == deviceElement)?.ProcessDataValue;
             if (dlv != null)
             {
                 lastValue = (int)dlv;

--- a/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
+++ b/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
@@ -1,3 +1,7 @@
+v0.19.5.4
+- FIX: TryGetDDIValue in Time Elements, Converter to Version 3, Totals and Lifetime Totals might crash in case the coresponding list was empty
+
+
 v0.19.5.2
 - FIX: In case the DataTransferOrign was MICS, the generated IDs were still positive as the TransferOrign was not handed on to the IDList
 


### PR DESCRIPTION
-FIX: TryGetDDIValue could crash with invalid Operation if a Value did not exist