### PR TITLE
Change target framework to .NET Standard 2.0

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML/Analysis/ISODeviceAnalysis.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Analysis/ISODeviceAnalysis.cs
@@ -58,7 +58,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Analysis
             {
                 return null;
             }
-            device ??= GetDeviceFromDeviceElement(entry.DeviceElementId);
+            if (device is null)
+            {
+                device = GetDeviceFromDeviceElement(entry.DeviceElementId);
+            }
             var dorList = device.DeviceElement.Where(det => det.DeviceElementId == entry.DeviceElementId)
                 .SelectMany(det => det.DeviceObjectReference).Select(dor => dor.DeviceObjectId).ToList();
             return
@@ -81,7 +84,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Analysis
                 return null;
             }
 
-            device ??= GetDeviceFromDeviceElement(entry.DeviceElementId);
+            if (device is null)
+            {
+                device = GetDeviceFromDeviceElement(entry.DeviceElementId);
+            }
             var dorList = device.DeviceElement.Where(det => det.DeviceElementId == entry.DeviceElementId)
                 .SelectMany(det => det.DeviceObjectReference).Select(dor => dor.DeviceObjectId).ToList();
 

--- a/Dev4Agriculture.ISO11783.ISOXML/Analysis/ISOTaskAnalysis.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Analysis/ISOTaskAnalysis.cs
@@ -68,7 +68,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Analysis
                     {
                         if (startTimestamp == null && logData.DDIValue == 1)
                         {
-                            info.StartDate ??= logData.TimeStamp;
+                            if (info.StartDate is null)
+                            {
+                                info.StartDate = logData.TimeStamp;
+                            }
                             startTimestamp = logData.TimeStamp;
                         }
                         else if (startTimestamp != null && logData.DDIValue == 0)
@@ -146,7 +149,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Analysis
 
             foreach (var workingElement in elementWorkTimes)
             {
-                var device = _isoxml.Data.Device.FirstOrDefault(s => s.DeviceElement.Any(s => s.DeviceElementId == workingElement.DdiEntry.DeviceElementId));
+                var device = _isoxml.Data.Device.FirstOrDefault(s => s.DeviceElement.Any(e => e.DeviceElementId == workingElement.DdiEntry.DeviceElementId));
                 var cpt = new CulturalPracticeInfo()
                 {
                     DeviceElementId = workingElement.DdiEntry.DeviceElementId,

--- a/Dev4Agriculture.ISO11783.ISOXML/Converters/DeviceClassConversion.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Converters/DeviceClassConversion.cs
@@ -2,37 +2,69 @@
 {
     public class DeviceClassConversion
     {
-        public static CulturalPracticesType MapDeviceClassToPracticeType(DeviceClass className) => className switch
+        public static CulturalPracticesType MapDeviceClassToPracticeType(DeviceClass className)
         {
-            DeviceClass.NonSpecificSystem => CulturalPracticesType.Unknown,
-            DeviceClass.Tractor => CulturalPracticesType.Unknown,
-            DeviceClass.PrimarySoilTillage => CulturalPracticesType.Tillage,
-            DeviceClass.SecondarySoilTillage => CulturalPracticesType.Tillage,
-            DeviceClass.PlantersSeeders => CulturalPracticesType.SowingAndPlanting,
-            DeviceClass.Fertilizer => CulturalPracticesType.Fertilizing,
-            DeviceClass.Sprayers => CulturalPracticesType.CropProtection,
-            DeviceClass.Harvesters => CulturalPracticesType.Harvesting,
-            DeviceClass.RootHarvester => CulturalPracticesType.Harvesting,
-            DeviceClass.ForageHarvester => CulturalPracticesType.ForageHarvesting,
-            DeviceClass.Irrigation => CulturalPracticesType.Irrigation,
-            DeviceClass.TransportTrailers => CulturalPracticesType.Transport,
-            DeviceClass.FarmyardWork => CulturalPracticesType.Unknown,
-            DeviceClass.PoweredAuxilaryUnits => CulturalPracticesType.Unknown,
-            DeviceClass.SpecialCrops => CulturalPracticesType.Unknown,
-            DeviceClass.MunicipalWork => CulturalPracticesType.Unknown,
-            DeviceClass.UnDefined16 => CulturalPracticesType.Unknown,
-            DeviceClass.SensorSystem => CulturalPracticesType.Unknown,
-            DeviceClass.ReservedForFutureAssignment => CulturalPracticesType.Unknown,
-            DeviceClass.TimberHarvesters => CulturalPracticesType.Harvesting,
-            DeviceClass.Forwarders => CulturalPracticesType.Transport,
-            DeviceClass.TimberLoaders => CulturalPracticesType.Transport,
-            DeviceClass.TimberProcessingMachines => CulturalPracticesType.Unknown,
-            DeviceClass.Mulchers => CulturalPracticesType.Mulching,
-            DeviceClass.UtilityVehicles => CulturalPracticesType.Unknown,
-            DeviceClass.FeederMixer => CulturalPracticesType.Unknown,
-            DeviceClass.SlurryApplicators => CulturalPracticesType.SlurryManureApplication,
-            DeviceClass.Reserved => CulturalPracticesType.Unknown,
-            _ => CulturalPracticesType.Unknown
-        };
+            switch (className)
+            {
+                case DeviceClass.NonSpecificSystem:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.Tractor:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.PrimarySoilTillage:
+                    return CulturalPracticesType.Tillage;
+                case DeviceClass.SecondarySoilTillage:
+                    return CulturalPracticesType.Tillage;
+                case DeviceClass.PlantersSeeders:
+                    return CulturalPracticesType.SowingAndPlanting;
+                case DeviceClass.Fertilizer:
+                    return CulturalPracticesType.Fertilizing;
+                case DeviceClass.Sprayers:
+                    return CulturalPracticesType.CropProtection;
+                case DeviceClass.Harvesters:
+                    return CulturalPracticesType.Harvesting;
+                case DeviceClass.RootHarvester:
+                    return CulturalPracticesType.Harvesting;
+                case DeviceClass.ForageHarvester:
+                    return CulturalPracticesType.ForageHarvesting;
+                case DeviceClass.Irrigation:
+                    return CulturalPracticesType.Irrigation;
+                case DeviceClass.TransportTrailers:
+                    return CulturalPracticesType.Transport;
+                case DeviceClass.FarmyardWork:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.PoweredAuxilaryUnits:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.SpecialCrops:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.MunicipalWork:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.UnDefined16:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.SensorSystem:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.ReservedForFutureAssignment:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.TimberHarvesters:
+                    return CulturalPracticesType.Harvesting;
+                case DeviceClass.Forwarders:
+                    return CulturalPracticesType.Transport;
+                case DeviceClass.TimberLoaders:
+                    return CulturalPracticesType.Transport;
+                case DeviceClass.TimberProcessingMachines:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.Mulchers:
+                    return CulturalPracticesType.Mulching;
+                case DeviceClass.UtilityVehicles:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.FeederMixer:
+                    return CulturalPracticesType.Unknown;
+                case DeviceClass.SlurryApplicators:
+                    return CulturalPracticesType.SlurryManureApplication;
+                case DeviceClass.Reserved:
+                    return CulturalPracticesType.Unknown;
+                default:
+                    return CulturalPracticesType.Unknown;
+            };
+        }
     }
 }

--- a/Dev4Agriculture.ISO11783.ISOXML/Converters/V3Converter.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Converters/V3Converter.cs
@@ -195,7 +195,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Converters
                 {
                     var thirdbit = propAsByteArray.ElementAt(3);
                     thirdbit = 0;
-                    item.DeviceProcessDataProperty = (byte)BitConverter.ToInt16(propAsByteArray); // p.99
+                    item.DeviceProcessDataProperty = (byte)BitConverter.ToInt16(propAsByteArray, 0); // p.99
                 }
             }
 

--- a/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
+++ b/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Dev4Agriculture.ISO11783.ISOXML</RootNamespace>
     <Version>0.22.1</Version>
     <Company>dev4Agriculture</Company>

--- a/Dev4Agriculture.ISO11783.ISOXML/Emulator/Generators/DeviceGenerator.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Emulator/Generators/DeviceGenerator.cs
@@ -159,7 +159,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Emulator.Generators
             };
             if (detId != null)
             {
-                var det = _device.DeviceElement.FirstOrDefault(det => det.DeviceElementId == detId);
+                var det = _device.DeviceElement.FirstOrDefault(de => de.DeviceElementId == detId);
                 det?.DeviceObjectReference.Add(dor);
             }
             else

--- a/Dev4Agriculture.ISO11783.ISOXML/Emulator/TaskControllerEmulator.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Emulator/TaskControllerEmulator.cs
@@ -514,7 +514,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Emulator
                 throw new NoTaskStartedException();
             }
 
-            var index = _currentTimeLog.Header.GetOrAddDataLogValue(ddi, (int)deviceElement!);
+            var index = _currentTimeLog.Header.GetOrAddDataLogValue(ddi, deviceElement.Value);
             if (index < _currentDataLine.Entries.Length && !_currentDataLine.Entries[index].IsSet)
             {
                 _currentDataLine.Entries[index].Value = value;
@@ -700,7 +700,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Emulator
 
 
 
-            var potentialDPDs = device.DeviceProcessData.Where(dpd => DDIUtils.ConvertDDI(dpd.DeviceProcessDataDDI) == ddi);
+            var potentialDPDs = device.DeviceProcessData.Where(dpd2 => DDIUtils.ConvertDDI(dpd2.DeviceProcessDataDDI) == ddi);
             if (!potentialDPDs.Any())
             {
                 _factors.Add(new WorkSessionFactor()

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOPartFieldExtension.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOExtensions/ISOPartFieldExtension.cs
@@ -67,7 +67,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
 
         public bool IsOverlappingBounds(FieldBounds bounds)
         {
-            Bounds ??= CalculateBounds();
+            if (Bounds is null)
+            {
+                Bounds = CalculateBounds();
+            }
 
             return !(
                 Bounds.MaxLong < bounds.MinLong ||
@@ -112,12 +115,12 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TaskFile
 
             var p1 = exterior.Point.ToList();
             var p2 = exteriorSecond.Point.ToList();
-            if (p1[0].PointNorth == p1[^1].PointNorth && p1[0].PointEast == p1[^1].PointEast)
+            if (p1[0].PointNorth == p1[p1.Count - 1].PointNorth && p1[0].PointEast == p1[p1.Count - 1].PointEast)
             {
                 p1.RemoveAt(p1.Count - 1);
             }
 
-            if (p2[0].PointNorth == p2[^1].PointNorth && p2[0].PointEast == p2[^1].PointEast)
+            if (p2[0].PointNorth == p2[p2.Count - 1].PointNorth && p2[0].PointEast == p2[p2.Count - 1].PointEast)
             {
                 p2.RemoveAt(p2.Count - 1);
             }

--- a/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
@@ -481,7 +481,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML
                 {
                     loadingPath = FileUtils.GetParentFolder(path, filePath);
                 }
-                archive.ExtractToDirectory(path, true);
+                archive.ExtractToDirectory(path);
             }
             try
             {

--- a/Dev4Agriculture.ISO11783.ISOXML/IdHandling/IdTable.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/IdHandling/IdTable.cs
@@ -141,8 +141,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.IdHandling
         }
 
 
-#nullable enable
-        internal bool IsEmptyOrLinkToValidElement(string? idContent)
+        internal bool IsEmptyOrLinkToValidElement(string idContent)
         {
             if (string.IsNullOrEmpty(idContent))
             {

--- a/Dev4Agriculture.ISO11783.ISOXML/Serializer/IsoxmlSerializer.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Serializer/IsoxmlSerializer.cs
@@ -90,8 +90,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Serializer
             ns.Add("", "");
             var xmlWriterSettings = new XmlWriterSettings() { Indent = true };
             var ser = new XmlSerializer(typeof(ISO11783TaskDataFile));
-            using var xmlWriter = XmlWriter.Create(path, xmlWriterSettings);
-            ser.Serialize(xmlWriter, taskData, ns);
+            using (var xmlWriter = XmlWriter.Create(path, xmlWriterSettings))
+            {
+                ser.Serialize(xmlWriter, taskData, ns);
+            }
         }
 
         public string Serialize(object obj)
@@ -104,23 +106,27 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Serializer
             var xmlWriterSettings = new XmlWriterSettings() { Indent = true, Encoding = Encoding.UTF8 };
             var ser = new XmlSerializer(obj.GetType());
             var output = new StringWriterWithEncoding();
-            using var xmlWriter = XmlWriter.Create(output, xmlWriterSettings);
-            ser.Serialize(xmlWriter, obj, ns);
-            return output.ToString();
+            using (var xmlWriter = XmlWriter.Create(output, xmlWriterSettings))
+            {
+                ser.Serialize(xmlWriter, obj, ns);
+                return output.ToString();
+            }
         }
 
         public ISO11783TaskDataFile DeepClone(ISO11783TaskDataFile taskData)
         {
             var xmlWriterSettings = new XmlWriterSettings() { Indent = true };
             var ser = new XmlSerializer(typeof(ISO11783TaskDataFile));
-            using var stream = new MemoryStream();
-            using var xmlWriter = XmlWriter.Create(stream, xmlWriterSettings);
-            ser.Serialize(xmlWriter, taskData);
-            var xmlDoc = new XmlDocument();
-            stream.Position = 0;
-            xmlDoc.Load(stream);
-            var copiedTask = Deserialize(xmlDoc);
-            return (ISO11783TaskDataFile)copiedTask.Result;
+            using (var stream = new MemoryStream())
+            using (var xmlWriter = XmlWriter.Create(stream, xmlWriterSettings))
+            {
+                ser.Serialize(xmlWriter, taskData);
+                var xmlDoc = new XmlDocument();
+                stream.Position = 0;
+                xmlDoc.Load(stream);
+                var copiedTask = Deserialize(xmlDoc);
+                return (ISO11783TaskDataFile)copiedTask.Result;
+            }
         }
 
         // mainly for debugging

--- a/Dev4Agriculture.ISO11783.ISOXML/Serializer/LinkListSerializer.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Serializer/LinkListSerializer.cs
@@ -90,8 +90,10 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Serializer
             ns.Add("", "");
             var xmlWriterSettings = new XmlWriterSettings() { Indent = true, Encoding = Encoding.UTF8 };
             var ser = new XmlSerializer(typeof(ISO11783LinkListFile));
-            using var xmlWriter = XmlWriter.Create(path, xmlWriterSettings);
-            ser.Serialize(xmlWriter, taskData, ns);
+            using (var xmlWriter = XmlWriter.Create(path, xmlWriterSettings))
+            {
+                ser.Serialize(xmlWriter, taskData, ns);
+            }
         }
 
         // mainly for debugging

--- a/Dev4Agriculture.ISO11783.ISOXML/Utils/DDIUtils.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Utils/DDIUtils.cs
@@ -21,7 +21,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.Utils
         }
 
         public static byte[] FormatDDI(DDIList value) => FormatDDI((ushort)value);
-        public static ushort ConvertDDI(byte[] entry) => BitConverter.ToUInt16(entry.Reverse().ToArray());
+        public static ushort ConvertDDI(byte[] entry) => BitConverter.ToUInt16(entry.Reverse().ToArray(), 0);
         public static ushort ParseDDI(string entry) => Convert.ToUInt16(entry, 16);
     }
 }


### PR DESCRIPTION
If this library would target .NET Standard 2.0 (instead of 2.1), even more projects could potentially make use of it.

There are several changes that have to be made in order to satisfy the older C# language version and a few changes where the newer API is not available.