### PR TITLE
Leave TaskController information empty per default

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/ISOXML.cs
@@ -185,8 +185,6 @@ namespace Dev4Agriculture.ISO11783.ISOXML
             {
                 ManagementSoftwareManufacturer = "unknown",
                 ManagementSoftwareVersion = "unknown",
-                TaskControllerManufacturer = "unknown",
-                TaskControllerVersion = "unknown",
                 DataTransferOrigin = ISO11783TaskDataFileDataTransferOrigin.FMIS
             };
             Grids = new Dictionary<string, ISOGridFile>();


### PR DESCRIPTION
I'm not too sure about this, but since `TaskControllerManufacturer` and `TaskControllerVersion` are optional attributes, shouldn't the default be to leave them empty (e.g. don't generate them)?