### PR TITLE
Add guidance pattern (GPN) to `IdTable`

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML/IdHandling/IdTable.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/IdHandling/IdTable.cs
@@ -26,6 +26,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.IdHandling
             AddList("DET", typeof(ISODeviceElement));
             AddList("FRM", typeof(ISOFarm));
             AddList("GGP", typeof(ISOGuidanceGroup));
+            AddList("GPN", typeof(ISOGuidancePattern));
             AddList("LSG", typeof(ISOLineString));
             AddList("OTQ", typeof(ISOOperationTechnique));
             AddList("PFD", typeof(ISOPartfield));


### PR DESCRIPTION
The `ISOGuidancePattern` ("GPN") does not generate an ID when done with the `AddObjectAndAssignIdIfNone` method.

Adding it to the `IdTable` should solve this. (I'm not sure if I should be adding any tests... let me know if I should, maybe with some pointers where it should be added.)