### PR TITLE
Bugfix/enqueue incomplete timelogs

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML.Test/EnqueuerSingulatorTests.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML.Test/EnqueuerSingulatorTests.cs
@@ -320,8 +320,8 @@ public class EnqueuerSingulatorTests
         {
             var tim = new ISOTime()
             {
-                Start = DateTime.Now.AddDays(-1 * a - 1),
-                Stop = DateTime.Now.AddDays(-1 * a),
+                Start = DateTime.Now.AddDays(-1 * (10 - a)),
+                Stop = DateTime.Now.AddDays(-1 * (9 - a)).AddSeconds(-1),
                 Type = ISOType2.Effective
             };
             for (var b = 10; b > a; b--)

--- a/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
@@ -4,7 +4,7 @@
     {
         //TODO It's more save to move this Element to a common class. It's found in Generator and DotnetCore Library
         public static string ISOXMLClassName = "Dev4Agriculture.ISO11783.ISOXML";
-        public static string Version = "V0.24.2.2";//Currently unused; Just for the commit
+        public static string Version = "V0.24.2.3";//Currently unused; Just for the commit
         public static string Author = "Frank Wiebeler, dev4Agriculture";
         public const int TLG_VALUE_FOR_NO_VALUE = int.MinValue;
         public const double EarthRadiusInMeters = 6378137;

--- a/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
+++ b/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Dev4Agriculture.ISO11783.ISOXML</RootNamespace>
-    <Version>0.24.2.2</Version>
+    <Version>0.24.2.3</Version>
     <Company>dev4Agriculture</Company>
     <Title>ISOXML DotNet Library</Title>
     <Authors>Frank Wiebeler, Alexander Parshin, Dima Robuliak</Authors>
@@ -16,9 +16,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>isoxml;agriculture;iso11783;taskcontroller;taskdata.xml;taskdata;smart-farming;farming;machine-data</PackageTags>
-    <Version>0.24.2.2</Version>
-    <AssemblyVersion>0.24.2.2</AssemblyVersion>
-    <FileVersion>0.24.2.2</FileVersion>
+    <Version>0.24.2.3</Version>
+    <AssemblyVersion>0.24.2.3</AssemblyVersion>
+    <FileVersion>0.24.2.3</FileVersion>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/RELEASE-Notes.txt"))</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
+++ b/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
@@ -1,3 +1,6 @@
+v0.24.2.3:
+    -FIX: When the second TIM-Element had less DLV entries than the first one, the missing DLVs were not added to the second TIM
+
 v0.24.2.2:
     -FIX: PositionElement had Attributes Latitude and Longitude that applied a wrong factor
 

--- a/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeListEnqueuer.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeListEnqueuer.cs
@@ -79,6 +79,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TimeLog
                         dlv.ProcessDataValue = dlvHandler.EnqueueValueAsDataLogValueInTime(dlv.ProcessDataValue, currentTim, deviceElement, devices);
                     }
                 }
+                //Fill up all DLVs that were in the previous but not in the current TIM
                 foreach (var dlv in completeDLVList)
                 {
                     if (!currentTim.TryGetDataLogValue(DDIUtils.ConvertDDI(dlv.ProcessDataDDI), IdList.ToIntId(dlv.DeviceElementIdRef), out _))
@@ -86,20 +87,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TimeLog
                         currentTim.DataLogValue.Add(dlv);
                     }
                 }
-                completeDLVList.Clear();
-                foreach (var dlv in currentTim.DataLogValue)
-                {
-                    completeDLVList.Add( new ISODataLogValue()
-                    {
-                        ProcessDataDDI = dlv.ProcessDataDDI,
-                        DataLogPGN = dlv.DataLogPGN,
-                        DataLogPGNStartBit = dlv.DataLogPGNStartBit,
-                        DataLogPGNStopBit = dlv.DataLogPGNStopBit,
-                        DataLogPGNValue = dlv.DataLogPGNValue,
-                        ProcessDataValue = dlv.ProcessDataValue,
-                        DeviceElementIdRef = dlv.DeviceElementIdRef,
-                    });
-                }
+                completeDLVList = currentTim.DataLogValue.ToList();
             }
             return times;
         }

--- a/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeListEnqueuer.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeListEnqueuer.cs
@@ -49,12 +49,12 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TimeLog
 
         public static List<ISOTime> EnqueueTimeElements(List<ISOTime> times, List<ISODevice> devices)
         {
+            var completeDLVList = new List<ISODataLogValue>();
             times = times.OrderBy(entry => entry.Start).ToList();
-            Dictionary<string, IDDITotalsFunctions> DataLogValues = new Dictionary<string, IDDITotalsFunctions>();
-            ISOTime previousTim = null;
-            foreach( var currentTim in times)
+            var dataLogValues = new Dictionary<string, IDDITotalsFunctions>();
+            foreach (var currentTim in times)
             {
-                if(currentTim.Type != ISOType2.Effective)
+                if (currentTim.Type != ISOType2.Effective)
                 {
                     continue;
                 }
@@ -68,18 +68,38 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TimeLog
                     {
                         continue;
                     }
-                    if (!DataLogValues.TryGetValue(key, out var dlvHandler))
+                    if (!dataLogValues.TryGetValue(key, out var dlvHandler))
                     {
                         dlvHandler = DDIAlgorithms.FindTotalDDIHandler(ddi, deviceElement, device);
 
-                        DataLogValues.Add(key, dlvHandler);
+                        dataLogValues.Add(key, dlvHandler);
                     }
                     if (dlvHandler != null)
                     {
                         dlv.ProcessDataValue = dlvHandler.EnqueueValueAsDataLogValueInTime(dlv.ProcessDataValue, currentTim, deviceElement, devices);
                     }
                 }
-
+                foreach (var dlv in completeDLVList)
+                {
+                    if (!currentTim.TryGetDataLogValue(DDIUtils.ConvertDDI(dlv.ProcessDataDDI), IdList.ToIntId(dlv.DeviceElementIdRef), out _))
+                    {
+                        currentTim.DataLogValue.Add(dlv);
+                    }
+                }
+                completeDLVList.Clear();
+                foreach (var dlv in currentTim.DataLogValue)
+                {
+                    completeDLVList.Add( new ISODataLogValue()
+                    {
+                        ProcessDataDDI = dlv.ProcessDataDDI,
+                        DataLogPGN = dlv.DataLogPGN,
+                        DataLogPGNStartBit = dlv.DataLogPGNStartBit,
+                        DataLogPGNStopBit = dlv.DataLogPGNStopBit,
+                        DataLogPGNValue = dlv.DataLogPGNValue,
+                        ProcessDataValue = dlv.ProcessDataValue,
+                        DeviceElementIdRef = dlv.DeviceElementIdRef,
+                    });
+                }
             }
             return times;
         }

--- a/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeLogEnqueuer.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/TimeLog/ISOTimeLogEnqueuer.cs
@@ -62,7 +62,7 @@ namespace Dev4Agriculture.ISO11783.ISOXML.TimeLog
                 foreach (var pair in previousData)
                 {
                     pair.Value.Function.UpdateTimeLogEnqueuerWithDataLine(line);
-                    if(line.Entries.Length >= pair.Value.Index && line.Entries[pair.Value.Index].IsSet)
+                    if (line.Entries.Length >= pair.Value.Index && line.Entries[pair.Value.Index].IsSet)
                     {
                         line.Entries[pair.Value.Index].Value = pair.Value.Function.EnqueueUpdatedValueInTimeLog(line.Entries[pair.Value.Index].Value);
                     }


### PR DESCRIPTION
When a TIM-Element did not include all DLVs from the previous element, we misst DataLogValues