### PR TITLE
Updating to V0.24.2.4 as we accidently called the Pipeline for Release at a wrong point in time/with the wrong version of the code)

### DIFF
--- a/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
+++ b/Dev4Agriculture.ISO11783.ISOXML/Constants.cs
@@ -4,7 +4,7 @@
     {
         //TODO It's more save to move this Element to a common class. It's found in Generator and DotnetCore Library
         public static string ISOXMLClassName = "Dev4Agriculture.ISO11783.ISOXML";
-        public static string Version = "V0.24.2.3";//Currently unused; Just for the commit
+        public static string Version = "V0.24.2.4";//Currently unused; Just for the commit
         public static string Author = "Frank Wiebeler, dev4Agriculture";
         public const int TLG_VALUE_FOR_NO_VALUE = int.MinValue;
         public const double EarthRadiusInMeters = 6378137;

--- a/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
+++ b/Dev4Agriculture.ISO11783.ISOXML/Dev4Agriculture.ISO11783.ISOXML.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Dev4Agriculture.ISO11783.ISOXML</RootNamespace>
-    <Version>0.24.2.3</Version>
+    <Version>0.24.2.4</Version>
     <Company>dev4Agriculture</Company>
     <Title>ISOXML DotNet Library</Title>
     <Authors>Frank Wiebeler, Alexander Parshin, Dima Robuliak</Authors>
@@ -16,9 +16,9 @@
     <RepositoryType>git</RepositoryType>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>isoxml;agriculture;iso11783;taskcontroller;taskdata.xml;taskdata;smart-farming;farming;machine-data</PackageTags>
-    <Version>0.24.2.3</Version>
-    <AssemblyVersion>0.24.2.3</AssemblyVersion>
-    <FileVersion>0.24.2.3</FileVersion>
+    <Version>0.24.2.4</Version>
+    <AssemblyVersion>0.24.2.4</AssemblyVersion>
+    <FileVersion>0.24.2.4</FileVersion>
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/RELEASE-Notes.txt"))</PackageReleaseNotes>
   </PropertyGroup>
 

--- a/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
+++ b/Dev4Agriculture.ISO11783.ISOXML/RELEASE-Notes.txt
@@ -1,6 +1,7 @@
-v0.24.2.3:
+v0.24.2.4:
     -FIX: When the second TIM-Element had less DLV entries than the first one, the missing DLVs were not added to the second TIM
-
+v0.24.2.3:
+    BURNED: Burned Version Number; do not use
 v0.24.2.2:
     -FIX: PositionElement had Attributes Latitude and Longitude that applied a wrong factor
 


### PR DESCRIPTION
With this update we mark V0.24.2.3 as BURNED